### PR TITLE
Issue5 - updates to linux_install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,51 @@
 # Edger
 Edger is a standalone system for developing for and using the combination of a WIFI-capable ESP32 and one or more Renesas/Dialog mixed signal FPGA chips or peripheral development boards and breakout boards having I2C interfaces. The Renesas/ForgeFPGA synthesis tool used to create FPGA images has a drag and drop GUI that involves zero Verilog or VHDL. It has a built in simulator and generates files that Edger can program in place in the user's system for simple FPGA applications. These FPGAs are around one to two dollars in single quantity, even ones mounted on a DIP board that can plug into a wireless breadboard. Edger is aimed at making FPGAs available to "the rest of us" while also creating a development ecosystem to augment the Espressif IDF and Arduino IDE.
 
+Actually that's how it started, but it has since evolved into a more generic system for communication between a web browser and a network-connected MCU or SBC.
+The first device supported is the ESP32.
+
+## Components
+The major components of Edger are:
+
+### ant
+Ant is the software that runs on the embedded device and provides REST-based access to device features like GPIO pins, I2C buses, etc.
+
+### aardvark
+Aardvark is a web interface based on VUE.js that allows for discovering and communicating with boards running Ant.  
+
+### the edger API
+The general concept for the edger API is as follows:
+* There is an endpoint for each type of functionality (e.g. /api/v1/i2c, /api/v1/gpio)
+* These endpoints are accessed via HTTP PATCH verb
+* The request payload is transmitted as one or more GET parameters, which:
+  * each have the form verb={"param1":"value1", "param2":"value2", ...}
+  * different verbs expect different parameters
+    * some verbs don't expect parameters but still must terminate with '=', e.g. /api/v1/i2c?scan=
+  * can be chained and will be processed in order for more complex functionality
+  * return their output as JSON
+
+## Development install
+A full Edger development environment allows for development of both ant and aardvark.  Therefore it includes the following components:
+* a clone of this Edger git repo
+* the Espressif IoT Development Framework (ESP-IDF) for building ant
+* node.js and pnpm for building aardvark, and optionally serving it in development mode for debugging
+* some scripts and Desktop icons to wrapper and expose the above functionality
+
+A convenience script is provided for installation on (currently Ubuntu) Linux - linux_install.sh
+This script does the following:
+1. Checks/clones the Edger repo (by default in $HOME/workspace/esp32/edger, or as specified by --with-edger={absolute-path})
+2. Checks/clones the ESP IDF (by default in $HOME/esp/esp-idf, or as specified by --with-esp-idf={absolute-path})
+3. Installs node.js using the Node Version Manager script - nvm.sh
+4. Uses Node Package Manager (npm) to install pnpm
+5. Uses pnpm to build aardvark
+6. Installs the ESP-IDF (creates $HOME/.espressif)
+7. Copies scripts to $HOME/bin:
+  a. changewifi - accepts input for wifi SSID and password, modifies the ant sdkconfig, and runs idf.py to build (and flash) ant
+  b. startaardvark - starts the node development server serving up the aardvark page/code
+8. (if $HOME/Desktop exists, indicating a graphical interface is installed) Copies Desktop files to create clickable icons:
+  a. CHANGE WIFI - runs the change wifi script
+  b. START AARDVARK - runs the startaardvark script
+  c. START BROWSER - opens the default browser to the local aardvark URL
+
 ## User group
 The user group kickoff meeting was held on 8/31/2022. Video here: https://youtu.be/zqejgwW3aIo

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ This script does the following:
 5. Uses pnpm to build aardvark
 6. Installs the ESP-IDF (creates $HOME/.espressif)
 7. Copies scripts to $HOME/bin:
-  a. changewifi - accepts input for wifi SSID and password, modifies the ant sdkconfig, and runs idf.py to build (and flash) ant
-  b. startaardvark - starts the node development server serving up the aardvark page/code
+  * changewifi - accepts input for wifi SSID and password, modifies the ant sdkconfig, and runs idf.py to build (and flash) ant
+  * startaardvark - starts the node development server serving up the aardvark page/code
 8. (if $HOME/Desktop exists, indicating a graphical interface is installed) Copies Desktop files to create clickable icons:
-  a. CHANGE WIFI - runs the change wifi script
-  b. START AARDVARK - runs the startaardvark script
-  c. START BROWSER - opens the default browser to the local aardvark URL
+  * CHANGE WIFI - runs the change wifi script
+  * START AARDVARK - runs the startaardvark script
+  * START BROWSER - opens the default browser to the local aardvark URL
 
 ## User group
 The user group kickoff meeting was held on 8/31/2022. Video here: https://youtu.be/zqejgwW3aIo

--- a/linux_install.sh
+++ b/linux_install.sh
@@ -26,9 +26,9 @@ When run with the --install argument, this script will do the following:
   * clones the $IDF_BRANCH_DEFAULT branch unless specified with --idf-branch
 3. Install node.js and pnpm (in standard places)
 4. Use pnpm to build aardvark
-5. Run the ESP IDF Installer (creates $HOME/.espressif)
-6. Copy changewifi and startaardvark scripts to $HOME/bin
-7. Copy icon files to $HOME/Desktop, if it exists
+5. Run the ESP IDF Installer (creates \$HOME/.espressif)
+6. Copy changewifi and startaardvark scripts to \$HOME/bin
+7. Copy icon files to \$HOME/Desktop, if it exists
 8. Make the following changes to \$HOME/.bashrc
   * add a line that appends \$HOME/bin to \$PATH, if not there already
   * add a function "exportidf" that will source the idf export.sh 
@@ -89,7 +89,7 @@ if [[ -z $IDF_DIR ]]; then
   IDF_DIR=$IDF_DIR_DEFAULT
 else
   if [[ ${IDF_DIR:0:1} != "/" ]]; then
-    echo "--esp-idf must be specified as absolute path"
+    echo "--idf must be specified as absolute path"
     arg_error=1
   fi
 fi


### PR DESCRIPTION
Addresses the following items from the last comment of issue5:
1. pnpm build (this was already there)
2. calls esp-idf install.sh in bash rather than sourcing it, so no need to set +u afterward
3. adds an "idfexport" function to local bashrc that will source the esp-idf export.sh, after which the idf.py command can be used as expected.  Updated the post-install message to mention this instead of the old wording.
4. (not addressed. this is coming from the upstream node install and/or the nvm.sh script)
5. (not addressed. as far as i can tell we just consume ESP-IDF functionality)
6. Left these as the default (which could optionally be changed to different values), but added --with-edger= and --with-esp-idf= optional arguments to specify different paths.  Made the corresponding changes in the script, and the install script updates the Desktop and bin scripts while copying them into place.
7. (not addressed)

I also updated the README.md to explain more about the different components of Edger, the components of the development environment, and what the linux_install.sh script does.

<i>Meta</i>: The reason it works that way is that Github markdown accepts (at least some) HTML markup for example the italicized and now bolded <b>Meta</b>, although you can use the code escape backticks to keep it from being interpreted, e.g. `<i>Meta</i>`