### PR TITLE
comment usb.getDevices from aardvark (and add apt-get update to ant linux_install)

### DIFF
--- a/aardvark/src/views/home/index.vue
+++ b/aardvark/src/views/home/index.vue
@@ -304,14 +304,14 @@ export default {
           'document.dispatchEvent(event);' +
           '})\n');
 
-      navigator.usb.getDevices().then((devices) => {
-        console.log(`Total devices: ${devices.length}`);
-        devices.forEach((device) => {
-          console.log(
-            `Product index: ${device.productName}, serial number ${device.serialNumber}`,
-          );
-        });
-      });
+//      navigator.usb.getDevices().then((devices) => {
+//        console.log(`Total devices: ${devices.length}`);
+//        devices.forEach((device) => {
+//          console.log(
+//            `Product index: ${device.productName}, serial number ${device.serialNumber}`,
+//          );
+//        });
+//      });
 
       document.addEventListener("index-of-event", function (e) {
         console.log("2", e.detail); // Prints "Example of an event"

--- a/aardvark/src/views/home/index.vue
+++ b/aardvark/src/views/home/index.vue
@@ -304,14 +304,14 @@ export default {
           'document.dispatchEvent(event);' +
           '})\n');
 
-//      navigator.usb.getDevices().then((devices) => {
-//        console.log(`Total devices: ${devices.length}`);
-//        devices.forEach((device) => {
-//          console.log(
-//            `Product index: ${device.productName}, serial number ${device.serialNumber}`,
-//          );
-//        });
-//      });
+      navigator.usb.getDevices().then((devices) => {
+        console.log(`Total devices: ${devices.length}`);
+        devices.forEach((device) => {
+          console.log(
+            `Product index: ${device.productName}, serial number ${device.serialNumber}`,
+          );
+        });
+      });
 
       document.addEventListener("index-of-event", function (e) {
         console.log("2", e.detail); // Prints "Example of an event"
@@ -319,7 +319,8 @@ export default {
     };
 
     onActivated(async () => {
-      testEvent()
+// not sure why this is needed, and it causes uncaught exceptions in navigator.usb.getDevices() above
+//      testEvent()
 
       const event = new CustomEvent("index-of-event", {"detail": "Example of an event"});
       // Dispatch/Trigger/Fire the event

--- a/ant/linux_install.sh
+++ b/ant/linux_install.sh
@@ -111,6 +111,7 @@ fi
 echo "==> Install the prerequisite packages"
 # python3, libusb-1.0-0, wget installed already on 20.04 and 22.04
 # python3-venv and python3-pip will install python3 as dep if needed
+sudo apt-get -q -q -y update
 sudo apt-get install -q -q -y \
   git  \
   python3-venv python3-pip \


### PR DESCRIPTION
Fixes #22 
* infinite spinner on Home screen due to undefined output from navigator.usb.getDevices()
  * (commented out that code like similar code is commented above)
  * Really not sure why aardvark needs USB since it should be running on any web-connected device
  * I think this is also bullet number 3 in the v0.1.0 issues list
 
Additionally:
* add apt-get update before apt-get install, since sources may be not-yet-initialized, or out-of-date