### PR TITLE
change idfexport function to idf.py alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ This script does the following:
   * CHANGE WIFI - runs the change wifi script
   * START AARDVARK - runs the startaardvark script
   * START BROWSER - opens the default browser to the local aardvark URL
+9. Appends to ~/.bashrc if it's not there already:
+  * append $HOME/bin to PATH
+  * alias for idf.py that will load the idf exports before running it
+  * env variables settings for NVM
 
 ## User group
 The user group kickoff meeting was held on 8/31/2022. Video here: https://youtu.be/zqejgwW3aIo

--- a/ant/linux_install.sh
+++ b/ant/linux_install.sh
@@ -214,17 +214,17 @@ if [ ! -d $HOME/.espressif ] ; then
   bash ./install.sh
 fi
 
-echo "==> checking for idfexport function in .bashrc"
-grep -q 'idfexport()' $HOME/.bashrc
+echo "==> checking for idf.py alias in .bashrc"
+grep -q 'alias idf.py=' $HOME/.bashrc
 if [ $? -eq 0 ]; then
-  grep 'idfexport()' $HOME/.bashrc | grep -q $IDF_DIR/export.sh
+  grep 'alias idf.py=' $HOME/.bashrc | grep -q $IDF_DIR/export.sh
   if [ $? -ne 0 ]; then
     echo "==> updating idf export path in $HOME/.bashrc"
-    sed -i "s:^idfexport.*:idfexport() { source $IDF_DIR/export.sh; }:" $HOME/.bashrc
+    sed -i "s:^alias idf.py=.*:idf.py='source $IDF_DIR/export.sh;unalias idf.py;idf.py':" $HOME/.bashrc
   fi
 else
-  echo "==> adding idfexport function to $HOME/.bashrc"
-  echo "idfexport() { source $IDF_DIR/export.sh; }" >> $HOME/.bashrc
+  echo "==> adding idf.py alias to $HOME/.bashrc"
+  echo "alias idf.py='source $IDF_DIR/export.sh;unalias idf.py;idf.py'" >> $HOME/.bashrc
 fi
 
 ## Not sure if we expect someone to source this and expect commands
@@ -239,5 +239,5 @@ fi
 ## print final message
 echo "Now use the change wifi icon (or changewifi script) to customize your dev board." 
 echo "It must be plugged in for this."
-echo "To use idf.py directly, first type idfexport."
+echo "You can also use idf.py directly, thanks to a bootstrap alias in .bashrc"
 echo "For any of this to work you'll need to log out and back in to load the changes made by the install script."

--- a/linux_install.sh
+++ b/linux_install.sh
@@ -157,5 +157,5 @@ fi
 ## print final message (note aardvark final message will precede this hence not mentioned)
 echo "Use the change wifi icon (or changewifi script) to customize, build, and flash ant"
 echo "to your dev board. It must be plugged in for this."
-echo "To use idf.py directly, first type idfexport."
+echo "You can also use idf.py directly, thanks to a bootstrap alias in .bashrc"
 echo "For any of this to work you'll need to log out and back in to load the changes made by the install script."


### PR DESCRIPTION
Per discussion in Signal, people might not remember to type "idfexport".  This replaces that function with a simple alias to idf.py that:
* sources the idf export file
* unaliases idf.py
* runs idf.py (with any other options that were supplied on the command line)